### PR TITLE
feat: Update build command to include production flag for app deployment

### DIFF
--- a/frappe_deployer/deployment_manager.py
+++ b/frappe_deployer/deployment_manager.py
@@ -1496,7 +1496,7 @@ class DeploymentManager:
                 )
 
             # Run the regular build command
-            build_cmd = [self.bench_cli, "build", "--app", app.name]
+            build_cmd = [self.bench_cli, "build", "--production", "--app", app.name]
 
             self.host_run(
                 build_cmd,


### PR DESCRIPTION
```
╰─➤  bench build --help
Usage: bench  build [OPTIONS]

  Compile JS and CSS source files

Options:
  --app TEXT        Build assets for app
  --apps TEXT       Build assets for specific apps
  --hard-link       Copy the files instead of symlinking
  --production      Build assets in production mode
  --verbose         Verbose
  --force           Force build assets instead of downloading available
  --save-metafiles  Saves esbuild metafiles for built assets. Useful for
                    analyzing bundle size. More info:
                    https://esbuild.github.io/api/#metafile
  --help            Show this message and exit.
  ```
  
  
This pull request makes a small change to the build process in the `bench_build` method of `frappe_deployer/deployment_manager.py`. The build command now includes the `--production` flag when building an app, ensuring that production-specific optimizations are applied during the build.