### PR TITLE
feat: respect app installation order from config apps list

### DIFF
--- a/frappe_deployer/build_manager.py
+++ b/frappe_deployer/build_manager.py
@@ -829,10 +829,9 @@ class BuildManager:
                 # "--compile-bytecode"
                 "-e",
             ]
-            apps = [d for d in bench_directory.apps.iterdir() if d.is_dir()]
-            for app in apps:
+            for app_path in self._get_app_paths_in_config_order(bench_directory):
                 self.host_run(
-                    install_cmd + [f"apps/{app.name}"],
+                    install_cmd + [f"apps/{app_path.name}"],
                     bench_directory,
                     # stream=False,
                     container=self.mode == "fm",
@@ -873,9 +872,7 @@ class BuildManager:
         self.printer.print(f"Apps python env install time: {elapsed_time:.2f} seconds")
 
         self.printer.change_head("Configuring apps.txt")
-        # Get all directory names in bench_directory.apps
-        apps_dir = bench_directory.apps
-        app_names = [d.name for d in apps_dir.iterdir() if d.is_dir()]
+        app_names = [app_path.name for app_path in self._get_app_paths_in_config_order(bench_directory)]
 
         # Save the list to bench_directory.sites / 'apps.txt'
         apps_txt_path = bench_directory.sites / "apps.txt"
@@ -886,6 +883,15 @@ class BuildManager:
                 app_name = bench_directory.get_app_python_module_name(bench_directory.apps / app_name)
                 f.write(f"{app_name}\n")
         self.printer.print("Configured apps.txt")
+
+    def _get_app_paths_in_config_order(self, bench_directory: BenchDirectory) -> list[Path]:
+        """Return app paths in the same order as `self.apps`, filtered to existing directories."""
+        app_paths: list[Path] = []
+        for app_config in self.apps:
+            app_path = bench_directory.apps / app_config.dir_name
+            if app_path.is_dir():
+                app_paths.append(app_path)
+        return app_paths
 
     def bench_build(self, bench_directory: BenchDirectory):
         # apps: list[Union[AppConfig, Path]] = self.apps

--- a/frappe_deployer/deployment_manager.py
+++ b/frappe_deployer/deployment_manager.py
@@ -1146,11 +1146,19 @@ class DeploymentManager:
         else:
             self.printer.print(f"Installed app {app_python_module_name} in {self.site_name}")
 
+    def _get_app_paths_in_config_order(self, bench_directory: BenchDirectory) -> list[Path]:
+        """Return app paths in the same order as `self.apps`, filtered to existing directories."""
+        app_paths: list[Path] = []
+        for app_config in self.apps:
+            app_path = bench_directory.apps / app_config.dir_name
+            if app_path.is_dir():
+                app_paths.append(app_path)
+        return app_paths
+
     def bench_install_apps(self, bench_directory: BenchDirectory) -> None:
         """Main function to handle installation and migration process."""
-        apps = [d for d in bench_directory.apps.iterdir() if d.is_dir()]
-        for app in apps:
-            self._install_app(bench_directory.apps / app.name, bench_directory)
+        for app_path in self._get_app_paths_in_config_order(bench_directory):
+            self._install_app(app_path, bench_directory)
 
     def host_run(
         self,
@@ -1393,10 +1401,9 @@ class DeploymentManager:
                 "-U",
                 "-e",
             ]
-            apps = [d for d in bench_directory.apps.iterdir() if d.is_dir()]
-            for app in apps:
+            for app_path in self._get_app_paths_in_config_order(bench_directory):
                 self.host_run(
-                    install_cmd + [f"apps/{app.name}"],
+                    install_cmd + [f"apps/{app_path.name}"],
                     bench_directory,
                     # stream=False,
                     container=self.mode == "fm",
@@ -1437,9 +1444,7 @@ class DeploymentManager:
         self.printer.print(f"Apps python env install time: {elapsed_time:.2f} seconds")
 
         self.printer.change_head("Configuring apps.txt")
-        # Get all directory names in bench_directory.apps
-        apps_dir = bench_directory.apps
-        app_names = [d.name for d in apps_dir.iterdir() if d.is_dir()]
+        app_names = [app_path.name for app_path in self._get_app_paths_in_config_order(bench_directory)]
 
         # Save the list to bench_directory.sites / 'apps.txt'
         apps_txt_path = bench_directory.sites / "apps.txt"


### PR DESCRIPTION
This pull request refactors how app directories are discovered and processed in both `frappe_deployer/build_manager.py` and `frappe_deployer/deployment_manager.py`. The main improvement is to ensure that app operations (such as installation and configuration) follow the order defined in the configuration (`self.apps`), rather than relying on the filesystem order. A new helper method, `_get_app_paths_in_config_order`, is introduced to encapsulate this logic and is reused across relevant methods.

**Refactoring app discovery and ordering:**

* Introduced the `_get_app_paths_in_config_order` helper method in both `BuildManager` and `DeploymentManager` to return app directories in the order defined by `self.apps`, filtered to only include existing directories. [[1]](diffhunk://#diff-01d864eae45e19a8221fc96125c46a0208223a583b26e50989660eee07cb7e17R887-R895) [[2]](diffhunk://#diff-c5f6768cdbc8b124061ff8ffa4e348da9721ebf69c871644f85ea884c24f081eR1149-R1161)
* Updated app installation loops in `bench_install_all_apps_in_python_env` and `bench_install_apps` to use the new helper, ensuring apps are processed in config order. [[1]](diffhunk://#diff-01d864eae45e19a8221fc96125c46a0208223a583b26e50989660eee07cb7e17L832-R834) [[2]](diffhunk://#diff-c5f6768cdbc8b124061ff8ffa4e348da9721ebf69c871644f85ea884c24f081eL1396-R1406) [[3]](diffhunk://#diff-c5f6768cdbc8b124061ff8ffa4e348da9721ebf69c871644f85ea884c24f081eR1149-R1161)
* Modified the logic for generating the `apps.txt` file in `bench_setup_requiments` to use the new helper, guaranteeing the order in the file matches the configuration. [[1]](diffhunk://#diff-01d864eae45e19a8221fc96125c46a0208223a583b26e50989660eee07cb7e17L876-R875) [[2]](diffhunk://#diff-c5f6768cdbc8b124061ff8ffa4e348da9721ebf69c871644f85ea884c24f081eL1440-R1447)