### PR TITLE
build(deps-dev): update pytest-mock to >=3.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ mike = { git = "https://github.com/squidfunk/mike.git" }
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",
-    "pytest-mock>=3.15.0",
+    "pytest-mock>=3.15.1",
     "pytest-cov>=7.1.0",
     "zensical",
     "mike",

--- a/uv.lock
+++ b/uv.lock
@@ -240,8 +240,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "frappe-manager", git = "https://github.com/rtcamp/frappe-manager.git?rev=develop" },
-    { name = "gitpython", specifier = ">=3.1.43,<4.0.0" },
-    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "gitpython", specifier = ">=3.1.46,<4.0.0" },
+    { name = "pydantic", specifier = ">=2.13.3,<3.0.0" },
     { name = "toml", specifier = ">=0.10.2,<0.11.0" },
     { name = "typer", specifier = ">=0.21.0,<0.22.0" },
     { name = "typer-examples", git = "https://github.com/Xieyt/typer-examples?tag=v1.1.0" },
@@ -251,8 +251,8 @@ requires-dist = [
 dev = [
     { name = "mike", git = "https://github.com/squidfunk/mike.git" },
     { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-mock", specifier = ">=3.15.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "zensical" },
 ]
 


### PR DESCRIPTION
## Summary
Updates `pytest-mock` to the latest version (`>=3.15.1`).

This completes the dependency updates that were started by Dependabot PRs.

## Context
- PR #31 (pytest-mock update) had merge conflicts after other Dependabot PRs were merged
- This PR includes that update along with regenerated lock file

## Related PRs
- Closes the remaining update from #31
- Complements already-merged PRs: #32, #33, #34

## Changes
- `pytest-mock`: `>=3.15.0` → `>=3.15.1`
- Regenerated `uv.lock` with all latest compatible versions