### PR TITLE
fix(deps): security bumps for 7 Dependabot alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Alok Singh", email = "alokmilenium@gmail.com" }]
 dependencies = [
     "frappe-manager",
-    "gitpython>=3.1.46,<4.0.0",
+    "gitpython>=3.1.50,<4.0.0",
     "typer>=0.21.0,<0.22.0",
     "toml>=0.10.2,<0.11.0",
     "pydantic>=2.13.3,<3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -783,11 +783,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -305,11 +305,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -566,15 +566,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "10.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -240,7 +240,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "frappe-manager", git = "https://github.com/rtcamp/frappe-manager.git?rev=develop" },
-    { name = "gitpython", specifier = ">=3.1.46,<4.0.0" },
+    { name = "gitpython", specifier = ">=3.1.50,<4.0.0" },
     { name = "pydantic", specifier = ">=2.13.3,<3.0.0" },
     { name = "toml", specifier = ">=0.10.2,<0.11.0" },
     { name = "typer", specifier = ">=0.21.0,<0.22.0" },
@@ -293,14 +293,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bd/50db468e9b1310529a19fce651b3b0e753b5c07954d486cba31bbee9a5d5/gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd", size = 216978, upload-time = "2026-04-22T02:44:44.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/c5/a1bc0996af85757903cf2bf444a7824e68e0035ce63fb41d6f76f9def68b/gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905", size = 209547, upload-time = "2026-04-22T02:44:41.271Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Applies Dependabot-resolved, same-major (safe) dependency bumps to address **7 security alerts**. Each change is a cherry-pick (`-x`) of the corresponding `dependabot[bot]` `uv.lock` commit, reusing Dependabot's exact resolved edits.

## Alerts fixed

| Package | Old → New | Alert # | Severity | Advisory |
|---|---|---|---|---|
| idna | 3.12 → 3.15 | #41 | Moderate | GHSA-jjg7-2v4v-x38h |
| pymdown-extensions | 10.21.2 → 10.21.3 | #39 | Moderate | GHSA-jh85-wwv9-24hv |
| urllib3 | 2.6.3 → 2.7.0 | #38, #36 | Moderate | GHSA-pq67-6m6q-mj2v / GHSA-48p4-8xcf-vxj5 |
| GitPython | 3.1.47 → 3.1.50 | #34, #32, #30 | High | GHSA-2mqj-m65w-jghx (+ related) |

GitPython also bumps the `pyproject.toml` constraint `gitpython>=3.1.46,<4.0.0` → `gitpython>=3.1.50,<4.0.0` (still `<4`, no major change).

## Why
All bumps are within the same major version, so they are low-risk and API-compatible. They were already resolved by Dependabot (PRs #50, #51, #49, #48); this PR consolidates them into a single lockfile-only change set off `main`.

## How tested
- **uv/pip were NOT run locally** (lockfile-only change set, intentional disk discipline).
- Reused Dependabot's already-resolved `uv.lock` edits via `git cherry-pick -x`.
- Validated that `uv.lock` and `pyproject.toml` both parse as valid TOML.
- Functional verification deferred to **CI** on this branch.

## Residual risk (not addressed here)
- **cryptography #43** (46.0.7 → 48.0.1): a **MAJOR** version bump — excluded from this PR; needs separate review/testing.
- **16 `poetry.lock` alerts** (#42, #40, #37, #35, #33, #31, #29, #28, #27, #26, #25, #24, #23, #22, #20, #19): **STALE** — this repo has no `poetry.lock` (uses `uv.lock` only). Recommend maintainer **dismissal**.

---
*Authored by rtBot. Do not merge without CI review.*
