### PR TITLE
fix(bench): run before_bench_build hook script from the release dir, not hard-coded /workspace/frappe-bench

### DIFF
--- a/fmd/services/bench.py
+++ b/fmd/services/bench.py
@@ -85,8 +85,14 @@ class BenchService:
             script_dir.mkdir(parents=True, exist_ok=True)
             script_name = f"temp_script_{int(time.time())}.sh"
             script_path = script_dir / script_name
-            container_script_path = f"/workspace/frappe-bench/.fmd_tmp/{script_name}"
-            workdir = custom_workdir or "/workspace/frappe-bench"
+            # Derive the container path from the same bench_directory the script was
+            # written to. During a deploy this is the release dir (mounted at
+            # /workspace/release_<ts>/), not /workspace/frappe-bench -- hard-coding the
+            # latter makes the container look in the wrong dir and fail with exit 127
+            # (bash: .../\.fmd_tmp/temp_script_*.sh: No such file or directory).
+            container_workdir = self.runner.workdir_for_bench(bench_directory)
+            container_script_path = f"{container_workdir}/.fmd_tmp/{script_name}"
+            workdir = custom_workdir or container_workdir
         else:
             script_dir = bench_directory.path / "deployment_tmp"
             script_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

Any app with a `before_bench_build` (or `host_before_bench_build`) hook fails during `fmd deploy pull` with exit code 127:

```
bash: /workspace/frappe-bench/.fmd_tmp/temp_script_1784101022.sh: No such file or directory
```

### Root cause

In `BenchService._run_script` (`fmd/services/bench.py`), when `container=True` the temp hook script is written under `bench_directory` on the host:

```python
script_dir = bench_directory.path / ".fmd_tmp"   # host: .../workspace/release_<ts>/.fmd_tmp/
script_path = script_dir / script_name
```

…but the container is told to execute it from a **hard-coded** path:

```python
container_script_path = f"/workspace/frappe-bench/.fmd_tmp/{script_name}"
```

During a deploy, `bench_directory` is the **release** directory (`self.new`, passed down from `bench_build`), which mounts into the container at `/workspace/release_<ts>/`, **not** `/workspace/frappe-bench/`. So the container looks in the wrong directory and the file isn't there → exit 127.

The `bench_build` node/fnm setup a few lines above already handles this correctly with a comment noting "Must use container path, not host path":

```python
container_workdir = self.runner.workdir_for_bench(bench_directory)
```

`_run_script` just didn't do the same translation.

## Fix

Derive the container script path (and the default `workdir`) from `self.runner.workdir_for_bench(bench_directory)` — the same `bench_directory` the script was written under — instead of hard-coding `/workspace/frappe-bench`.

## Impact

Affects every deploy whose config uses a `before_bench_build` hook. Concrete example (rtCamp GoDAM app-set): `frappe/helpdesk` (`git submodule update --init --recursive`) and `rtcamp/godam-core` (writes `frontend/.env`, installs `godam-transcoder`) both fail on `main`.

## Testing

Applied this change to a local `uv tool` install of fmd `main` (1.1.0) and re-ran `fmd deploy pull godam.localhost` with the GoDAM config. Both hooks now run and the full ~18-app deploy completes and switches the release; site serves (`/api/method/ping` → 200). Without the change the deploy dies at the helpdesk hook every time.

## Notes

- The `container=False` (host) branch is unaffected — it already uses `str(script_path)`.
- No behavior change for configs without build hooks.