### PR TITLE
Enhance remote worker configuration and rsync operations

### DIFF
--- a/fmd/commands/remote_worker.py
+++ b/fmd/commands/remote_worker.py
@@ -63,7 +63,7 @@ def enable(
         remote_worker["ssh_port"] = rw_port
     if remote_worker:
         overrides["remote_worker"] = remote_worker
-    config = load_config(config_path, overrides=overrides if overrides else None)
+    config = load_config(config_path, overrides=overrides if overrides else None, skip_repo_validation=True)
     printer = get_printer()
     printer.start("Working")
     manager = RemoteWorkerManager(config, printer)
@@ -115,7 +115,7 @@ def sync(
         remote_worker["ssh_port"] = rw_port
     if remote_worker:
         overrides["remote_worker"] = remote_worker
-    config = load_config(config_path, overrides=overrides if overrides else None)
+    config = load_config(config_path, overrides=overrides if overrides else None, skip_repo_validation=True)
     printer = get_printer()
     printer.start("Working")
     manager = RemoteWorkerManager(config, printer)

--- a/fmd/config/remote_worker.py
+++ b/fmd/config/remote_worker.py
@@ -11,6 +11,10 @@ class RemoteWorkerConfig(BaseModel):
     ssh_port: Optional[int] = Field(22, description="SSH port number")
     include_dirs: Optional[List[str]] = Field(default_factory=list, description="Additional directories to sync")
     include_files: Optional[List[str]] = Field(default_factory=list, description="Additional files to sync")
+    exclude_patterns: Optional[List[str]] = Field(
+        default_factory=list,
+        description="Additional rsync exclude patterns (e.g. '**/large_dir/', '*.tmp')",
+    )
 
     @property
     def fm_benches_path(self) -> str:

--- a/fmd/managers/remote_worker.py
+++ b/fmd/managers/remote_worker.py
@@ -219,6 +219,8 @@ class RemoteWorkerManager:
             "--exclude=**/__pycache__/***",
             "--exclude=**/.pytest_cache/***",
             "--exclude=**/.cache/***",
+            "--exclude=**/env.bak/***",
+            "--exclude=**/env.backup.*/***",
             "--exclude=*.pyc",
             "--exclude=*.pyo",
             "--exclude=*.pyd",

--- a/fmd/managers/remote_worker.py
+++ b/fmd/managers/remote_worker.py
@@ -79,7 +79,8 @@ class RemoteWorkerManager:
         self.ssh = SSHClient(rw.server_ip, rw.ssh_user, rw.ssh_port)
         self.current = BenchDirectory(config.bench_path)
         self.data = BenchDirectory(config.workspace_root / DATA_DIR_NAME)
-        self._remote_base = Path(rw.fm_benches_path) / config.site_name / "workspace"
+        self._site_base = Path(rw.fm_benches_path) / config.site_name
+        self._remote_base = self._site_base / "workspace"
 
     def _fm_bench(self):
         from frappe_manager.docker import ComposeFile
@@ -200,9 +201,11 @@ class RemoteWorkerManager:
                     "--timeout",
                     "10",
                 ],
-                workdir=str(self._remote_base),
+                workdir=str(self._site_base),
             )
             self.printer.print("Stopped all remote-worker services")
+        except RuntimeError:
+            self.printer.print("No remote-worker services to stop (first sync?)")
         except RuntimeError:
             self.printer.print("No remote-worker services to stop (first sync?)")
 
@@ -326,18 +329,18 @@ class RemoteWorkerManager:
 
     def _only_start_workers_compose_services(self) -> None:
         self.printer.change_head("Stopping all services other than workers")
-        self.ssh.run_list(["docker", "compose", "-f", "docker-compose.yml", "down"], workdir=str(self._remote_base))
+        self.ssh.run_list(["docker", "compose", "-f", "docker-compose.yml", "down"], workdir=str(self._site_base))
         self.ssh.run_list(
             ["docker", "compose", "-f", "docker-compose.yml", "up", "-d", "schedule"],
-            workdir=str(self._remote_base),
+            workdir=str(self._site_base),
         )
         self.printer.change_head("Starting remote-worker services")
         self.ssh.run_list(
             ["docker", "compose", "-f", "docker-compose.workers.yml", "up", "-d"],
-            workdir=str(self._remote_base),
+            workdir=str(self._site_base),
         )
         self.ssh.run_list(
             ["docker", "compose", "-f", "docker-compose.workers.yml", "restart"],
-            workdir=str(self._remote_base),
+            workdir=str(self._site_base),
         )
         self.printer.print("Started remote-worker services")

--- a/fmd/managers/remote_worker.py
+++ b/fmd/managers/remote_worker.py
@@ -187,21 +187,24 @@ class RemoteWorkerManager:
 
     def _stop_all_compose_services(self) -> None:
         self.printer.change_head("Stop all remote-worker services")
-        self.ssh.run_list(
-            [
-                "docker",
-                "compose",
-                "-f",
-                "docker-compose.yml",
-                "-f",
-                "docker-compose.workers.yml",
-                "down",
-                "--timeout",
-                "10",
-            ],
-            workdir=str(self._remote_base),
-        )
-        self.printer.print("Stopped all remote-worker services")
+        try:
+            self.ssh.run_list(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    "docker-compose.yml",
+                    "-f",
+                    "docker-compose.workers.yml",
+                    "down",
+                    "--timeout",
+                    "10",
+                ],
+                workdir=str(self._remote_base),
+            )
+            self.printer.print("Stopped all remote-worker services")
+        except RuntimeError:
+            self.printer.print("No remote-worker services to stop (first sync?)")
 
     def _rsync_workspace(self) -> None:
         site_name = self.config.site_name

--- a/fmd/managers/remote_worker.py
+++ b/fmd/managers/remote_worker.py
@@ -231,6 +231,9 @@ class RemoteWorkerManager:
             "--exclude=*.sql",
         ]
 
+        for pattern in self.rw.exclude_patterns or []:
+            rsync_patterns.append(f"--exclude={pattern}")
+
         ssh_opt = f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p {self.rw.ssh_port}"
 
         rsync_dirs = [

--- a/fmd/managers/remote_worker.py
+++ b/fmd/managers/remote_worker.py
@@ -78,7 +78,7 @@ class RemoteWorkerManager:
         self.rw = rw
         self.ssh = SSHClient(rw.server_ip, rw.ssh_user, rw.ssh_port)
         self.current = BenchDirectory(config.bench_path)
-        self.data = BenchDirectory(config.workspace_root / DATA_DIR_NAME)
+        self.data = BenchDirectory(config.workspace_root / "workspace" / DATA_DIR_NAME)
         self._site_base = Path(rw.fm_benches_path) / config.site_name
         self._remote_base = self._site_base / "workspace"
 


### PR DESCRIPTION
This pull request introduces improvements to the remote worker sync process, including enhanced configuration options for excluding files, more robust service management, and adjustments to workspace paths. These changes make remote worker operations more flexible and resilient, especially when handling first-time syncs or custom file exclusion needs.

**Configuration and Exclusion Enhancements:**
* Added an `exclude_patterns` field to the `RemoteWorkerConfig` model, allowing users to specify additional rsync exclude patterns for syncing.
* Updated the rsync logic in `RemoteWorkerManager` to append user-defined exclude patterns from the config, and added default excludes for `env.bak` and `env.backup.*` directories [[1]](diffhunk://#diff-5b98792e355dd063493bb0cd7b2148bc9063c7d0b895f2115d5e07624a403916R222-R223) [[2]](diffhunk://#diff-5b98792e355dd063493bb0cd7b2148bc9063c7d0b895f2115d5e07624a403916R234-R236).

**Workspace and Path Handling:**
* Changed the local and remote workspace/data directory paths to be more consistent and robust by adjusting how `self.data`, `self._site_base`, and `self._remote_base` are set up.

**Service Management Robustness:**
* Improved error handling in stopping remote-worker services: if there are no services to stop (e.g., on first sync), a user-friendly message is printed instead of raising an error [[1]](diffhunk://#diff-5b98792e355dd063493bb0cd7b2148bc9063c7d0b895f2115d5e07624a403916R191) [[2]](diffhunk://#diff-5b98792e355dd063493bb0cd7b2148bc9063c7d0b895f2115d5e07624a403916L202-R210).

**Consistency in Docker Compose Operations:**
* Standardized the working directory for all Docker Compose commands to use `self._site_base` instead of `self._remote_base`, ensuring commands run in the correct context.

**Config Loading Behavior:**
* Updated `enable` and `sync` commands to load the config with `skip_repo_validation=True`, which can speed up or avoid unnecessary repo checks during these operations [[1]](diffhunk://#diff-b9a85278aec5594d770f498699b526e6c88fe5642a9a144fa3e6e9c7bc11beedL66-R66) [[2]](diffhunk://#diff-b9a85278aec5594d770f498699b526e6c88fe5642a9a144fa3e6e9c7bc11beedL118-R118).