### PR TITLE
Add remote deploy configuration and standardize app installation

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -228,6 +228,36 @@ host_after_restart = ""
 # Script on host after bench restart
 
 # ============================================================================
+# SHIP: Remote Deploy Configuration
+# ============================================================================
+# Settings for `fmd deploy ship` - build the release locally (or in CI, inside
+# Docker), rsync it to a remote server over SSH, then finalize the switch there.
+# Only required when using ship mode. See NOTES for the pull vs ship tradeoff.
+
+[ship]
+host = ""
+# Remote server hostname or IP address. Required for ship mode.
+
+ssh_user = "frappe"
+# SSH username for the remote server. Default: "frappe"
+
+ssh_port = 22
+# SSH port. Default: 22
+
+remote_path = ""
+# Absolute path on the remote server where the bench/workspace lives.
+# Empty = auto-detect as "$HOME/frappe/sites/<site_name>" (resolves remote $HOME
+# over SSH, falling back to "/home/<ssh_user>/frappe/sites/<site_name>").
+
+fmd_source = ""
+# FMD source used to run fmd on the remote via uvx (git URL or local path).
+# Empty = auto-detect (uses the running fmd checkout, else installs from PyPI).
+
+rsync_options = []
+# Extra flags passed to rsync when syncing the release to the remote.
+# Example: ["--bwlimit=10000", "--compress-level=9"]
+
+# ============================================================================
 # FRAPPE CLOUD: Sync from Frappe Cloud
 # ============================================================================
 

--- a/fmd/services/bench.py
+++ b/fmd/services/bench.py
@@ -226,7 +226,13 @@ class BenchService:
                 )
 
             app_abs_path = f"{self.runner.workdir_for_bench(bench_directory)}/apps/{app.dir_name}"
-            self.runner.run(install_cmd + [app_abs_path], bench_directory, capture_output=False)
+            try:
+                self.runner.run(install_cmd + [app_abs_path], bench_directory, capture_output=False)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to install app '{app.dir_name}' in python env "
+                    f"(command: {' '.join(install_cmd + [app_abs_path])})"
+                ) from e
 
             if app.after_python_install:
                 self._run_script(

--- a/fmd/services/bench.py
+++ b/fmd/services/bench.py
@@ -225,13 +225,8 @@ class BenchService:
                     app_name=app.dir_name,
                 )
 
-            try:
-                app_abs_path = f"{self.runner.workdir_for_bench(bench_directory)}/apps/{app.dir_name}"
-                self.runner.run(install_cmd + [app_abs_path], bench_directory, capture_output=False)
-            except Exception:
-                self.printer.print(f"uv failed for {app.dir_name}, falling back to pip")
-                app_abs_path = f"{self.runner.workdir_for_bench(bench_directory)}/apps/{app.dir_name}"
-                self.runner.run(["pip", "install", "-e", app_abs_path], bench_directory, capture_output=False)
+            app_abs_path = f"{self.runner.workdir_for_bench(bench_directory)}/apps/{app.dir_name}"
+            self.runner.run(install_cmd + [app_abs_path], bench_directory, capture_output=False)
 
             if app.after_python_install:
                 self._run_script(


### PR DESCRIPTION
This pull request introduces configuration options for remote deployment using "ship" mode and simplifies the app installation logic in the bench service. The main changes are as follows:

**Remote Deploy Configuration:**

* Added a new `[ship]` section in `example-config.toml` for configuring remote deployments via `fmd deploy ship`, including options for SSH connection, remote paths, and rsync customization.

**Bench Service Logic Simplification:**

* Removed the fallback logic for installing apps with pip if the primary install command fails, so only the primary install method is now used in `bench_install_all_apps_in_python_env` in `fmd/services/bench.py`.